### PR TITLE
Fix Kratos registration hook syntax

### DIFF
--- a/config/kratos/kratos.example.yml
+++ b/config/kratos/kratos.example.yml
@@ -29,6 +29,10 @@ selfservice:
     registration:
       ui_url: http://localhost:8000/a/login
       lifespan: 1h
+      after:
+        oidc:
+          hooks:
+            - hook: session
     login:
       ui_url: http://localhost:8000/a/login
       lifespan: 1h


### PR DESCRIPTION
## Summary
- place the registration session hook under the OIDC method so Kratos issues a session after first-time social sign-ins

## Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fc2444cf908323a84d270f1c3db06e